### PR TITLE
Skip last line comment

### DIFF
--- a/lib/whois/scanners/whois.cira.ca.rb
+++ b/lib/whois/scanners/whois.cira.ca.rb
@@ -63,7 +63,7 @@ module Whois
       end
 
       tokenizer :skip_comment do
-        @input.skip(/^%.*\n/)
+        @input.skip(/^%.*(\n|$)/)
       end
 
     end


### PR DESCRIPTION
Today I see that ca tld does not work in this fork.
Investigation shows that last comment line was not skipped in the scanner.

With this PR it works fine now:

```
[8] pry(main)> Whois.whois('google.ca').parser.expires_on
=> 2022-04-28 04:00:00 UTC
[9] pry(main)> 
[10] pry(main)> Whois.whois('blackrockoilfield.ca').parser.expires_on
=> 2023-03-24 21:26:25 UTC
[11] pry(main)> 
```


